### PR TITLE
Update stack.c

### DIFF
--- a/stack.c
+++ b/stack.c
@@ -39,7 +39,7 @@ int pop()
     {
         int out;
         out=st.arr[st.top];
-        st.top++;
+        st.top--;
         return out;
     }
 }


### PR DESCRIPTION
# There is a logical error in the code
-  If we attempt to display for the best case then the all elements would be displayed
- But when we talk about the worst case when the elements are poped after pushing then only remaining elements sould be displayed , but here in this case the popedup elements are also displayed along with some zeros.  
- So this is the updated code for the same so that the memory of the pop element would be available for the next elements if pushed.  
**Hope this finds  great  & it would be great if you accept this pull request.**